### PR TITLE
client env vars, deploy script, build:prod script

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,7 @@
  .git
  .gitignore
  .dockerignore
+ dockerBuild.js
  Dockerfile
  Dockerfile_bu
  docker-compose.yml

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules
 dist
 .env
 docker-compose.yml
+dockerBuild.js
 package-lock.json
 public/main.js
 public/main.js.map

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:18
 
+ENV NODE_ENV=production
+
 WORKDIR /app
 
 COPY package*.json ./

--- a/client/Components/SpotifyLogin.js
+++ b/client/Components/SpotifyLogin.js
@@ -1,14 +1,18 @@
-import React from "react"
-import Container from "react-bootstrap/Container"
+import React from 'react'
+import Container from 'react-bootstrap/Container'
 
-const AUTH_URL =
-  "https://accounts.spotify.com/authorize?client_id=31c41df5075e46c48c3547d709102476&response_type=code&redirect_uri=http://localhost:3000&scope=streaming%20user-read-email%20user-read-private%20user-library-read%20user-library-modify%20user-read-playback-state%20user-modify-playback-state"
+const spotifyRedirect =
+  process.env.NODE_ENV === 'production'
+    ? process.env.SPOTIFY_REDIRECT_URI_PROD
+    : process.env.SPOTIFY_REDIRECT_URI_DEV
+
+const AUTH_URL = `https://accounts.spotify.com/authorize?client_id=${process.env.SPOTIFY_CLIENT_ID}&response_type=code&redirect_uri=${spotifyRedirect}&scope=streaming%20user-read-email%20user-read-private%20user-library-read%20user-library-modify%20user-read-playback-state%20user-modify-playback-state`
 
 export default function SpotifyLogin() {
   return (
     <Container
       className="d-flex justify-content-center align-items-center"
-      style={{ minHeight: "75vh" }}
+      style={{ minHeight: '75vh' }}
     >
       <a className="btn btn-success btn-lg" href={AUTH_URL}>
         Login With Spotify

--- a/package.json
+++ b/package.json
@@ -5,18 +5,23 @@
   "main": "index.js",
   "scripts": {
     "build": "webpack",
+    "build:prod": "NODE_ENV=${NODE_ENV:=production} npm run build -- --mode=production",
     "build:dev": "npm run build -- --watch --mode=development",
-    "start:dev": "nodemon --delay 3000ms server/index.js --ignore dist/ --ignore client/ --ignore debug/ --ignore public/audio/ & npm run build:dev ",
-    "start-server:dev": "nodemon --delay 500ms server/index.js --ignore dist/ --ignore client/ --ignore debug/ --ignore public/audio/",
-    "start-server:prod": "node server/index.js"
+    "start:dev": "NODE_ENV=${NODE_ENV:=development} nodemon --delay 3000ms server/index.js --ignore dist/ --ignore client/ --ignore debug/ --ignore public/audio/ & npm run build:dev ",
+    "start:prod": "NODE_ENV=${NODE_ENV:=production} node server/index.js & npm run build -- --mode=production",
+    "start-server:dev": "NODE_ENV=${NODE_ENV:=development} nodemon --delay 500ms server/index.js --ignore dist/ --ignore client/ --ignore debug/ --ignore public/audio/",
+    "start-server:prod": "NODE_ENV=${NODE_ENV:=production} node server/index.js",
+    "deploy": "NODE_ENV=${NODE_ENV:=production} npm run build:prod && node dockerBuild.js"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "dependencies": {
     "axios": "^1.5.0",
+    "child_process": "^1.0.2",
     "connect-session-sequelize": "^7.1.7",
     "dotenv": "^16.3.1",
+    "dotenv-webpack": "^8.0.1",
     "express": "^4.18.2",
     "express-session": "^1.17.3",
     "langchain": "^0.0.141",

--- a/server/routes/spotify.js
+++ b/server/routes/spotify.js
@@ -1,11 +1,16 @@
-const router = require("express").Router()
-const SpotifyWebApi = require("spotify-web-api-node")
-const { User, Profile } = require("../db")
+const router = require('express').Router()
+const SpotifyWebApi = require('spotify-web-api-node')
+const { User, Profile } = require('../db')
 
-router.post("/refresh", (req, res) => {
+const spotifyRedirect =
+  process.env.NODE_ENV === 'production'
+    ? process.env.SPOTIFY_REDIRECT_URI_PROD
+    : process.env.SPOTIFY_REDIRECT_URI_DEV
+
+router.post('/refresh', (req, res) => {
   const refreshToken = req.body.refreshToken
   const spotifyApi = new SpotifyWebApi({
-    redirectUri: process.env.SPOTIFY_REDIRECT_URI,
+    redirectUri: spotifyRedirect,
     clientId: process.env.SPOTIFY_CLIENT_ID,
     clientSecret: process.env.SPOTIFY_CLIENT_SECRET,
     refreshToken,
@@ -30,10 +35,11 @@ router.post("/refresh", (req, res) => {
     })
 })
 
-router.post("/login", (req, res) => {
+router.post('/login', (req, res) => {
+  console.log(process.env.NODE_ENV, spotifyRedirect)
   const code = req.body.code
   const spotifyApi = new SpotifyWebApi({
-    redirectUri: process.env.SPOTIFY_REDIRECT_URI,
+    redirectUri: spotifyRedirect,
     clientId: process.env.SPOTIFY_CLIENT_ID,
     clientSecret: process.env.SPOTIFY_CLIENT_SECRET,
   })
@@ -57,7 +63,7 @@ router.post("/login", (req, res) => {
             req.session.displayName = body.display_name
           },
           function (err) {
-            console.log("Something went wrong!", err)
+            console.log('Something went wrong!', err)
           }
         )
         .then(() => {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,30 +1,39 @@
-const path = require("path")
+const Dotenv = require('dotenv-webpack')
+const webpack = require('webpack')
+
+const path = require('path')
 
 module.exports = {
   entry: {
-    main: path.resolve(__dirname, "client/index.js"),
+    main: path.resolve(__dirname, 'client/index.js'),
   },
   output: {
-    path: path.resolve(__dirname, "public"),
-    filename: "main.js",
+    path: path.resolve(__dirname, 'public'),
+    filename: 'main.js',
     clean: false,
-    publicPath: "./",
+    publicPath: './',
   },
-  devtool: "source-map",
+  devtool: 'source-map',
   module: {
     rules: [
       {
         test: /\.js$/,
         exclude: /node_modules/,
-        loader: "babel-loader",
+        loader: 'babel-loader',
         options: {
-          presets: ["@babel/preset-react"],
+          presets: ['@babel/preset-react'],
         },
       },
       {
         test: /\.(sass|less|css)$/,
-        use: ["style-loader", "css-loader", "less-loader"],
+        use: ['style-loader', 'css-loader', 'less-loader'],
       },
     ],
   },
+  plugins: [
+    new Dotenv(),
+    new webpack.DefinePlugin({
+      'process.env': JSON.stringify(process.env),
+    }),
+  ],
 }


### PR DESCRIPTION
Integrated env variables into webpack
Added NODE_ENV production vs. development logic to write proper variables based on environment
Spotify login now uses right redirect url based on environment (server and client)
Add NODE_ENV variable to npm scripts
Edited Dockerfile to set NODE_ENV to production
Created build:prod npm script to webpack build for production
Add dockerBuild script
Created deploy npm script to do webpack build for production, docker build and docker push to registry
